### PR TITLE
update register-page.php

### DIFF
--- a/Ch02-simpleIdb/simpleIdb/register-page.php
+++ b/Ch02-simpleIdb/simpleIdb/register-page.php
@@ -51,7 +51,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 	// Register the user in the database...
 		require ('./mysqli_connect.php'); // Connect to the db.
 		// Make the query:
-		$q = "INSERT INTO users (user_id, fname, lname, email, psword, registration_date) VALUES (' ', '$fn', '$ln', '$e', SHA1('$p'), NOW() )";		
+		$q = "INSERT INTO users (fname, lname, email, psword, registration_date) VALUES ('$fn', '$ln', '$e', SHA1('$p'), NOW() )";		
 		$result = @mysqli_query ($dbcon, $q); // Run the query.
 		if ($result) { // If it ran OK.
 		header ("location: register-thanks.php"); 


### PR DESCRIPTION
In order to get a user_id that will be created automatically by the DBMS , we should not provide an empty string as its value and instead leave the value . 

In the book page 74, the reason of providing an empty string was : ' Note that the first value is deliberately empty (quotes with an empty space in between) because it is the field that is automatically incremented and entered by the MySQL or MariaDB database management system, not by the user.'

But when I tried the approach in the book, I got the an exception saying : Incorrect integer value: ' ' for column simpledb.users.user_id at row 1

The approach that worked for me is the one present in the branch (which is removing user_id from the insert statement and also removing the ' ' in the VALUES ) .